### PR TITLE
add bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+    "name": "angular-evaporate",
+    "version": "0.0.2",
+    "main": ["lib/angular-evaporate.js", "lib/evaporate.js"],
+    "description": "AngularJS module for the EvaporateJS library",
+    "keywords": ["upload", "resumable upload", "evaporate", "angular"],
+    "repository": {
+    "type": "git",
+        "url": "https://github.com/uquee/angular-evaporate.git"
+    },
+    "dependencies": {
+        "angular": "*"
+    },
+    "ignore": [
+        ".gitignore"
+    ]
+}


### PR DESCRIPTION
This will enable angular-evaporate to be pulled in using Bower.

As far as I understand you also need to create a tag `0.0.2` after you merged the PR  to make it work.

In the future, we should also specify the dependency to TTLabs/EvaporateJS or a suitable fork in the bower file.
