### PR TITLE
make timestamp separator configurable

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.1.0",
   "name": "angular-evaporate",
   "description": "AngularJS module for the EvaporateJS library",
   "keywords": [

--- a/example/index.js
+++ b/example/index.js
@@ -14,6 +14,11 @@ angular
       // if not specified, default value being used is: '' (matches bucket's root directory)
       dir: 'tmp',
 
+      // You can pick a different separator string that goes in between upload_datetime and filename_with_extension:
+      // http://<your_bucket>.s3.amazonaws.com/<dir>/<upload_datetime><this_value><filename_with_extension>
+      // if not specified, the default value being used is: '$'
+      timestampSeparator: '_',
+
       // headers which should (headersSigned) and should not (headersCommon) be signed by your private key
       // for details, visit http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
       headersCommon: {

--- a/lib/angular-evaporate.js
+++ b/lib/angular-evaporate.js
@@ -30,6 +30,7 @@
         // apply defaults for input parameters
         var data = scope.data,
             dir = data.dir ? (data.dir + '/') : '',
+            timestampSeparator = data.timestampSeparator || '$',
             headersCommon = data.headersCommon || {},
             headersSigned = data.headersSigned || {},
             onFileProgress = (typeof data.onFileProgress === 'function' ? data.onFileProgress : foo),
@@ -51,7 +52,7 @@
 
               // process file attrs
               file.started = Date.now();
-              file.path_ = dir + file.started + '$' + file.name;
+              file.path_ = dir + file.started + timestampSeparator + file.name;
               file.url = eva.urlBase + file.path_;
 
               // queue file for upload


### PR DESCRIPTION
Make it possible to pick a custom separator string that goes between the timestamp and the original file name. This makes it possible to upload files as: `1432833172096_myfile.txt` or `1432833172096---myfile.txt` instead of `1432833172096$myfile.txt`
