### PR TITLE
Allow overriding config options in EvaporateJs 2.0

### DIFF
--- a/lib/angular-evaporate.js
+++ b/lib/angular-evaporate.js
@@ -306,7 +306,7 @@
                 args[1] = upload.overrideConfig;
                 
                 // run
-                upload.$id = this.add.apply(this, arguments);
+                upload.$id = this.add.apply(this, args);
 
                 // modify api
                 delete upload.$start;

--- a/lib/angular-evaporate.js
+++ b/lib/angular-evaporate.js
@@ -73,6 +73,7 @@
            *
            * @property {String} name
            * @property {String} contentType
+           * @property {Object} overrideConfig - Allows for overriding global config options on a per-request basis
            *
            * @property {Number} $id - returned by the Evaporate.add()
            * @property {String} $url - full url of the file when it will be uploaded
@@ -301,7 +302,9 @@
                * @returns - same as Evaporate.add()
                */
               AngularEvaporate.prototype.$start = function (upload) {
-
+                var args = Array.prototype.slice.call(arguments);
+                args[1] = upload.overrideConfig;
+                
                 // run
                 upload.$id = this.add.apply(this, arguments);
 


### PR DESCRIPTION
In EvaporateJs 2.0, the Evaporate.add() function now takes a second argument, overrideConfig. This allows for overriding the global config settings for each request.

This patch allows for specifying a property on AngularEvaporateUpload called overrideConfig. If specified, this will be passed in to Evaporate.add() as a second argument.

I know Angular Evaporate doesn't officially support EvaporateJs 2.0 yet, but I think this patch is a useful workaround until proper support can be added.